### PR TITLE
style / fix (use --output option)

### DIFF
--- a/run.py
+++ b/run.py
@@ -6,21 +6,23 @@
 import os
 import argparse
 
-parser = argparse.ArgumentParser(
-    description='Setup')
-parser.add_argument('--setup', action='store_true',
-                    help='Set this flag if running for the first time')
+parser = argparse.ArgumentParser(description='Setup')
+parser.add_argument('--setup', action='store_true', help='Set this flag if running for the first time')
 args = parser.parse_args()
+
+setup_script_path = os.path.join('.', 'scripts', 'setup.sh')
+main_script_path = os.path.join('.', 'scripts', 'main.py')
 
 if os.name == 'posix' or os.name == 'darwin':
     if args.setup:
-        os.system("chmod u+x ./scripts/setup.sh")
-        os.system("./scripts/setup.sh")
+        os.system(f'chmod u+x {setup_script_path}')
+        os.system(f'{setup_script_path}')
+    os.system(f'python3 {main_script_path}')
 
-    os.system("python3 ./scripts/main.py")
-
-if os.name == 'nt':
+elif os.name == 'nt':
     if args.setup:
-        print("Need to develop code for this part") #TODO
+        raise NotImplementedError('TODO')
+    os.system(f'python {main_script_path}')
 
-    os.system("python ./scripts/main.py")
+else:
+    raise NotImplementedError

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -33,11 +33,12 @@ def main():
         raise NotImplementedError
 
     for elem in lst:
-        output_name, media_url = elem
+        video_stem, media_url = elem
+        video_name = video_stem + ".%(ext)s"
         if os.name == 'posix':
-            os.system(f'{path_binary} "{media_url}" -o "{output_name}"')
+            os.system(f'{path_binary} "{media_url}" -o "{video_name}"')
         elif os.name == 'nt':
-            os.system(f'{path_binary} {media_url} -o {output_name}')
+            os.system(f'{path_binary} {media_url} -o {video_name}')
         else:
             raise NotImplementedError
 

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -22,27 +22,24 @@ def main():
 
     if not lst:
         print("List is empty. Terminating program")
+        return
 
-    extensions = [".mp4", ".mkv"]
+    path_binary = None
     if os.name == 'posix':
         path_binary = os.path.join(".", "python_venv", "bin", "yt-dlp")
-
-    if os.name == 'nt':
+    elif os.name == 'nt':
         path_binary = os.path.join(".", "python_venv", "Scripts", "yt-dlp.exe")
-
-    path_file = os.path.join(".", "index-index")
+    else:
+        raise NotImplementedError
 
     for elem in lst:
+        output_name, media_url = elem
         if os.name == 'posix':
-            os.system(path_binary + " " + elem[1])
-        
-        if os.name == 'nt':
-            os.system(path_binary + " " + elem[1])
-
-        for ext in extensions:
-            path_file += ext
-            if os.path.isfile(path_file):
-                os.rename(path_file, elem[0] + ext)
+            os.system(f'{path_binary} "{media_url}" -o "{output_name}"')
+        elif os.name == 'nt':
+            os.system(f'{path_binary} {media_url} -o {output_name}')
+        else:
+            raise NotImplementedError
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### style

- 일부 경로는 os.path.join 을 사용했는데 일부 경로는 '/' 등을 이용해 명시적으로 지정되어 있는 등의 경우 수정
- 구현되지 않은 부분의 경우 명시적으로 notimplementederror 을 raise 하도록 수정

### fix

- #1 
- yt-dlp이 현재 --output (-o) 옵션을 지원하는 것을 확인하고 해당 명령어를 이용하도록 수정

### 기타

- 이제 chrome 의 video download helper 에서 copy url 을 제공하지 않으므로 README.md 의 수정이 필요해 보임.

---

![image](https://github.com/changh95/video-scraper/assets/46595649/9f38a3cf-f8cc-4ea1-89a2-8c849a50f974)
